### PR TITLE
fix flaky tests in the file EntityToSchemaMapperTest.java

### DIFF
--- a/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java
+++ b/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java
@@ -3,6 +3,7 @@ package io.github.vlsergey.springdatarestutils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.Link;
@@ -16,6 +17,8 @@ import io.github.vlsergey.springdatarestutils.CodebaseScannerFacade.ScanResult;
 import io.github.vlsergey.springdatarestutils.projections.TestEntityDefaultProjection;
 import io.github.vlsergey.springdatarestutils.test.TestEntity;
 import io.swagger.v3.oas.models.media.Schema;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.Yaml;
 
 class EntityToSchemaMapperTest {
 
@@ -23,6 +26,7 @@ class EntityToSchemaMapperTest {
 
     private final TaskProperties taskProperties = new TaskProperties().setAddXLinkedEntity(true);
 
+    private final Yaml yaml = new Yaml(new Constructor(Map.class));
     private final EntityToSchemaMapper mapper = new EntityToSchemaMapper(
 	    (a, b, c) -> ClassToRefResolver.generateName(taskProperties, a, b, c),
 	    new CustomAnnotationsHelper(taskProperties), TestEntity.class::equals,
@@ -31,9 +35,9 @@ class EntityToSchemaMapperTest {
     @Test
     void testLink() throws Exception {
 	final Schema<?> schema = mapper.mapEntity(Link.class, ClassMappingMode.DATA_ITEM, RequestType.RESPONSE);
-	String json = SchemaUtils.writeValueAsString(false, schema);
+	Map<String, Object> yamlMap = yaml.load(SchemaUtils.writeValueAsString(false, schema));
 
-	assertEquals("type: object\n" + //
+	assertEquals(yaml.load("type: object\n" + //
 		"properties:\n" + //
 		"  deprecation:\n" + //
 		"    type: string\n" + //
@@ -65,15 +69,15 @@ class EntityToSchemaMapperTest {
 		"  type:\n" + //
 		"    type: string\n" + //
 		"    nullable: false\n" + //
-		"", json);
+		""), yamlMap);
     }
 
     @Test
     void testMapAsDataItem() throws Exception {
 	final Schema<?> schema = mapper.mapEntity(TestEntity.class, ClassMappingMode.DATA_ITEM, RequestType.RESPONSE);
-	String json = SchemaUtils.writeValueAsString(false, schema);
+	Map<String, Object> yamlMap = yaml.load(SchemaUtils.writeValueAsString(false, schema));
 
-	assertEquals("required:\n" + //
+	assertEquals(yaml.load("required:\n" + //
 		"- created\n" + //
 		"- id\n" + //
 		"- parent\n" + //
@@ -96,15 +100,15 @@ class EntityToSchemaMapperTest {
 		"    type: string\n" + //
 		"    format: date-time\n" + //
 		"    nullable: false\n" + //
-		"", json);
+		""), yamlMap);
     }
 
     @Test
     void testMapAsExposed() throws Exception {
 	final Schema<?> schema = mapper.mapEntity(TestEntity.class, ClassMappingMode.EXPOSED, RequestType.RESPONSE);
-	String json = SchemaUtils.writeValueAsString(false, schema);
+	Map<String, Object> yamlMap = yaml.load(SchemaUtils.writeValueAsString(false, schema));
 
-	assertEquals("required:\n" + //
+	assertEquals(yaml.load("required:\n" + //
 		"- created\n" + //
 		"- id\n" + //
 		"- updated\n" + //
@@ -122,15 +126,15 @@ class EntityToSchemaMapperTest {
 		"    type: string\n" + //
 		"    format: date-time\n" + //
 		"    nullable: false\n" + //
-		"", json);
+		""), yamlMap);
     }
 
     @Test
     void testMapAsLinks() throws Exception {
 	final Schema<?> schema = mapper.mapEntity(TestEntity.class, ClassMappingMode.LINKS, RequestType.RESPONSE);
-	String json = SchemaUtils.writeValueAsString(false, schema);
+	Map<String, Object> yamlMap = yaml.load(SchemaUtils.writeValueAsString(false, schema));
 
-	assertEquals("required:\n" + //
+	assertEquals(yaml.load("required:\n" + //
 		"- _links\n" + //
 		"type: object\n" + //
 		"properties:\n" + //
@@ -149,15 +153,15 @@ class EntityToSchemaMapperTest {
 		"        allOf:\n" + //
 		"        - $ref: '#/components/schemas/Link'\n" + //
 		"        x-linked-entity: TestEntity\n" + //
-		"", json);
+		""), yamlMap);
     }
 
     @Test
     void testUriTemplate() throws Exception {
 	final Schema<?> schema = mapper.mapEntity(UriTemplate.class, ClassMappingMode.DATA_ITEM, RequestType.RESPONSE);
-	String json = SchemaUtils.writeValueAsString(false, schema);
+	Map<String, Object> yamlMap = yaml.load(SchemaUtils.writeValueAsString(false, schema));
 
-	assertEquals("required:\n" //
+	assertEquals(yaml.load("required:\n" //
 		+ "- variableNames\n" //
 		+ "- variables\n" //
 		+ "type: object\n" //
@@ -173,7 +177,7 @@ class EntityToSchemaMapperTest {
 		+ "    nullable: false\n" //
 		+ "    items:\n" //
 		+ "      $ref: '#/components/schemas/TemplateVariable'\n" //
-		+ "", json);
+		+ ""), yamlMap);
     }
 
     @Test


### PR DESCRIPTION
This PR aims to fix the following 5 flaky test cases:

[io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testLink](https://github.com/ThugJudy/spring-data-rest-utils/blob/4a327ce5688eaf2faed077daaaf43621859d67b2/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java#L35)
[io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsDataItem
](https://github.com/ThugJudy/spring-data-rest-utils/blob/4a327ce5688eaf2faed077daaaf43621859d67b2/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java#L75)[io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsExposed
](https://github.com/ThugJudy/spring-data-rest-utils/blob/4a327ce5688eaf2faed077daaaf43621859d67b2/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java#L106C1-L107C1)[io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsLinks](https://github.com/ThugJudy/spring-data-rest-utils/blob/4a327ce5688eaf2faed077daaaf43621859d67b2/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java#L132)
[io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testUriTemplate
](https://github.com/ThugJudy/spring-data-rest-utils/blob/4a327ce5688eaf2faed077daaaf43621859d67b2/src/test/java/io/github/vlsergey/springdatarestutils/EntityToSchemaMapperTest.java#L159)

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

**Problem:**
The writeValueAsString() function is nondeterministic and when it tries to convert a YAML object to a string, it does not account for the ordering of elements of the YAML object.  
https://github.com/ThugJudy/spring-data-rest-utils/blob/8cd30dfd4ab0ab817fdd5ffe14b567f8dc6169d3/src/main/java/io/github/vlsergey/springdatarestutils/SchemaUtils.java#L33
Hence, all the tests mentioned above when they try to call the SchemaUtils.writeValueAsString() function,  are prone to flakiness.

**Solution:**

Since we do not have access to the internal library, I have added a check, that converts the YAML string to YAML objects and then compares the objects.

**Steps to reproduce**

**Integrate NonDex:**

**Add the following snippet to the top of the build.gradle in $PROJ_DIR:**
```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

**Append to build.gradle in $PROJ_DIR:**
```
apply plugin: 'edu.illinois.nondex'
```

**Execute Test with Gradle:**
```
./gradlew --info test --tests io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testLink
./gradlew --info test --tests io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsDataItem
./gradlew --info test --tests io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsExposed
./gradlew --info test --tests io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsLinks
./gradlew --info test --tests io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testUriTemplate

```

**Run NonDex:**
```
./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testLink 
./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsDataItem 
./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsExposed 
./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testMapAsLinks 
./gradlew --info nondexTest --tests=io.github.vlsergey.springdatarestutils.EntityToSchemaMapperTest.testUriTemplate 
```

**Test Environment:**
```
Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.
